### PR TITLE
Sync etcd cluster when connecting

### DIFF
--- a/etcdstoreadapter/etcd_store_adapter.go
+++ b/etcdstoreadapter/etcd_store_adapter.go
@@ -31,6 +31,10 @@ func NewETCDStoreAdapter(urls []string, workPool *workpool.WorkPool) *ETCDStoreA
 func (adapter *ETCDStoreAdapter) Connect() error {
 	adapter.client = etcd.NewClient(adapter.urls)
 
+	if !adapter.client.SyncCluster() {
+		return fmt.Errorf("cann't sync with the etcd cluster")
+	}
+
 	// should only really fail if an invalid consistency value is given,
 	// but might as well propagate to fit the interface.
 	return adapter.client.SetConsistency(etcd.STRONG_CONSISTENCY)

--- a/etcdstoreadapter/etcd_store_adapter_test.go
+++ b/etcdstoreadapter/etcd_store_adapter_test.go
@@ -43,6 +43,17 @@ var _ = Describe("ETCD Store Adapter", func() {
 		adapter.Disconnect()
 	})
 
+	Describe("Connect", func() {
+		Context("when server is down", func() {
+			It("should return an error", func() {
+				adapter = NewETCDStoreAdapter([]string{"http://127.0.0.1:6000"},
+					workpool.NewWorkPool(10))
+				err := adapter.Connect()
+				Ω(err).Should(HaveOccurred())
+			})
+		})
+	})
+
 	Describe("Get", func() {
 		BeforeEach(func() {
 			err := adapter.SetMulti([]StoreNode{breakfastNode, lunchNode})


### PR DESCRIPTION
If server is down, connect should return an error. So sync with the etcd cluster to make sure it's ok.