### PR TITLE
Enable wrapped/embedded errors for better info

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,16 +1,45 @@
 package storeadapter
 
-import (
-	"errors"
+const (
+	ErrorKeyNotFound = iota
+	ErrorNodeIsDirectory
+	ErrorNodeIsNotDirectory
+	ErrorTimeout
+	ErrorInvalidFormat
+	ErrorInvalidTTL
+	ErrorKeyExists
+	ErrorKeyComparisonFailed
+	ErrorOther
+
+	ErrorInvalidTTLDescription          = "got an invalid TTL"
+	ErrorKeyComparisonFailedDescription = "keys do not match"
+	ErrorKeyExistsDescription           = "key already exists in store"
+	ErrorKeyNotFoundDescription         = "key does not exist in store"
+	ErrorNodeIsDirectoryDescription     = "node is a directory, not a leaf"
+	ErrorNodeIsNotDirectoryDescription  = "node is a leaf, not a directory"
 )
 
-var (
-	ErrorKeyNotFound         = errors.New("the requested key could not be found")
-	ErrorNodeIsDirectory     = errors.New("node is a directory, not a leaf")
-	ErrorNodeIsNotDirectory  = errors.New("node is a leaf, not a directory")
-	ErrorTimeout             = errors.New("store request timed out")
-	ErrorInvalidFormat       = errors.New("node has invalid format")
-	ErrorInvalidTTL          = errors.New("got an invalid TTL")
-	ErrorKeyExists           = errors.New("a node already exists at the requested key")
-	ErrorKeyComparisonFailed = errors.New("node comparison failed")
-)
+type Error interface {
+	Error() string
+	Type() int
+}
+
+type customError struct {
+	err     error
+	errType int
+}
+
+func (e *customError) Error() string {
+	return e.err.Error()
+}
+
+func (e *customError) Type() int {
+	return e.errType
+}
+
+func NewError(err error, errType int) *customError {
+	return &customError{
+		err:     err,
+		errType: errType,
+	}
+}

--- a/etcdstoreadapter/etcd_store_adapter_test.go
+++ b/etcdstoreadapter/etcd_store_adapter_test.go
@@ -89,7 +89,13 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("When getting a non-existent key", func() {
 			It("should return an error", func() {
 				value, err := adapter.Get("/not_a_key")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
+
 				Expect(value).To(BeZero())
 			})
 		})
@@ -97,7 +103,13 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when getting a directory", func() {
 			It("should return an error", func() {
 				value, err := adapter.Get("/menu")
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
+
 				Expect(value).To(BeZero())
 			})
 		})
@@ -156,7 +168,12 @@ var _ = Describe("ETCD Store Adapter", func() {
 				}
 
 				err := adapter.SetMulti([]StoreNode{dirNode})
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 
@@ -292,7 +309,13 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when listing a non-existent key", func() {
 			It("should return an error", func() {
 				value, err := adapter.ListRecursively("/nothing-here")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
+
 				Expect(value).To(BeZero())
 			})
 		})
@@ -301,7 +324,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 			It("should return an error", func() {
 				value, err := adapter.ListRecursively("/menu/breakfast")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(Equal(ErrorNodeIsNotDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsNotDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsNotDirectory")
+				}
 				Expect(value).To(BeZero())
 			})
 		})
@@ -335,11 +362,19 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				value, err := adapter.Get("/menu/breakfast")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 				Expect(value).To(BeZero())
 
 				value, err = adapter.Get("/menu/lunch")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 				Expect(value).To(BeZero())
 			})
 		})
@@ -347,7 +382,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when deleting a non-existing key", func() {
 			It("should error", func() {
 				err := adapter.Delete("/not-a-key")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -357,10 +396,18 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = adapter.Get("/menu/breakfast")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 
 				_, err = adapter.Get("/menu")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -403,10 +450,18 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = adapter.Get(nodeFoo.Key)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 
 				_, err = adapter.Get(nodeBar.Key)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 
 			Context("but the comparison fails for one node", func() {
@@ -416,13 +471,21 @@ var _ = Describe("ETCD Store Adapter", func() {
 
 				It("returns an error", func() {
 					err := adapter.CompareAndDelete(nodeFoo, nodeBar)
-					Expect(err).To(Equal(ErrorKeyComparisonFailed))
+					if cErr, ok := err.(Error); ok {
+						Expect(cErr.Type()).To(Equal(ErrorKeyComparisonFailed))
+					} else {
+						Fail("expected error to be of type ErrorKeyComparisonFailed")
+					}
 
 					_, err = adapter.Get(nodeFoo.Key)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = adapter.Get(nodeBar.Key)
-					Expect(err).To(Equal(ErrorKeyNotFound))
+					if cErr, ok := err.(Error); ok {
+						Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+					} else {
+						Fail("expected error to be of type ErrorKeyNotFound")
+					}
 				})
 			})
 		})
@@ -430,7 +493,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when a node does not exist at the key", func() {
 			It("returns an error", func() {
 				err := adapter.CompareAndDelete(nodeFoo)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -442,7 +509,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				parentNode := StoreNode{Key: "/dir", Value: []byte("some value")}
 
 				err = adapter.CompareAndDelete(parentNode)
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})
@@ -479,10 +550,18 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = adapter.Get(nodeFoo.Key)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 
 				_, err = adapter.Get(nodeBar.Key)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 
 			Context("but the comparison fails for one node", func() {
@@ -491,13 +570,21 @@ var _ = Describe("ETCD Store Adapter", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					err = adapter.CompareAndDeleteByIndex(etcdNodeFoo, etcdNodeBar)
-					Expect(err).To(Equal(ErrorKeyComparisonFailed))
+					if cErr, ok := err.(Error); ok {
+						Expect(cErr.Type()).To(Equal(ErrorKeyComparisonFailed))
+					} else {
+						Fail("expected error to be of type ErrorKeyComparisonFailed")
+					}
 
 					_, err = adapter.Get(nodeFoo.Key)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = adapter.Get(nodeBar.Key)
-					Expect(err).To(Equal(ErrorKeyNotFound))
+					if cErr, ok := err.(Error); ok {
+						Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+					} else {
+						Fail("expected error to be of type ErrorKeyNotFound")
+					}
 				})
 			})
 		})
@@ -509,7 +596,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 
 			It("returns an error", func() {
 				err := adapter.CompareAndDeleteByIndex(nodeFoo)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -522,7 +613,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = adapter.CompareAndDeleteByIndex(parentNode)
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})
@@ -536,9 +631,12 @@ var _ = Describe("ETCD Store Adapter", func() {
 			_, err = adapter.Get("/menu/breakfast")
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() interface{} {
+			Eventually(func() int {
 				_, err = adapter.Get("/menu/breakfast")
-				return err
+				if cErr, ok := err.(Error); ok {
+					return cErr.Type()
+				}
+				return -1
 			}, 2, 0.01).Should(Equal(ErrorKeyNotFound)) // as of etcd v0.2rc1, etcd seems to take an extra 0.5 seconds to expire its TTLs
 		})
 	})
@@ -579,7 +677,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				uniqueStoreNodeForThisTest.TTL = 0
 
 				nodeStatus, releaseLock, err := adapter.MaintainNode(uniqueStoreNodeForThisTest)
-				Expect(err).To(Equal(ErrorInvalidTTL))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorInvalidTTL))
+				} else {
+					Fail("expected error to be of type ErrorInvalidTTL")
+				}
 				Expect(nodeStatus).To(BeNil())
 				Expect(releaseLock).To(BeNil())
 			})
@@ -762,7 +864,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when a node already exists at the key", func() {
 			It("returns an error", func() {
 				err := adapter.Create(node)
-				Expect(err).To(Equal(ErrorKeyExists))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyExists))
+				} else {
+					Fail("expected error to be of type ErrorKeyExists")
+				}
 			})
 		})
 
@@ -772,7 +878,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = adapter.Create(StoreNode{Key: "/dir", Value: []byte("some value")})
-				Expect(err).To(Equal(ErrorKeyExists))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyExists))
+				} else {
+					Fail("expected error to be of type ErrorKeyExists")
+				}
 			})
 		})
 	})
@@ -801,7 +911,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when a node does not exist at the key", func() {
 			It("returns an error", func() {
 				err := adapter.Update(node)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -811,7 +925,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = adapter.Update(StoreNode{Key: "/dir", Value: []byte("some value")})
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})
@@ -850,7 +968,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				newNode.Value = []byte("some new value")
 
 				err = adapter.CompareAndSwap(wrongNode, newNode)
-				Expect(err).To(Equal(ErrorKeyComparisonFailed))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyComparisonFailed))
+				} else {
+					Fail("expected error to be of type ErrorKeyComparisonFailed")
+				}
 
 				retrievedNode, err := adapter.Get("/foo")
 				Expect(err).NotTo(HaveOccurred())
@@ -861,7 +983,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when a node does not exist at the key", func() {
 			It("returns an error", func() {
 				err := adapter.CompareAndSwap(node, node)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -873,7 +999,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				newNode := StoreNode{Key: "/dir", Value: []byte("some value")}
 
 				err = adapter.CompareAndSwap(newNode, newNode)
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})
@@ -912,7 +1042,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				newNode.Value = []byte("some new value")
 
 				err = adapter.CompareAndSwapByIndex(4271138, newNode)
-				Expect(err).To(Equal(ErrorKeyComparisonFailed))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyComparisonFailed))
+				} else {
+					Fail("expected error to be of type ErrorKeyComparisonFailed")
+				}
 
 				retrievedNode, err := adapter.Get("/foo")
 				Expect(err).NotTo(HaveOccurred())
@@ -923,7 +1057,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 		Context("when a node does not exist at the key", func() {
 			It("returns an error", func() {
 				err := adapter.CompareAndSwapByIndex(4271338, node)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -935,7 +1073,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				newNode := StoreNode{Key: "/dir", Value: []byte("some value")}
 
 				err = adapter.CompareAndSwapByIndex(4271338, newNode)
-				Expect(err).To(Equal(ErrorNodeIsDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})
@@ -1265,14 +1407,22 @@ var _ = Describe("ETCD Store Adapter", func() {
 				time.Sleep(2 * time.Second)
 
 				_, err = adapter.Get("/menu/breakfast")
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
 		Context("When the directory does not exist", func() {
 			It("should return a ErrorKeyNotFound", func() {
 				err := adapter.UpdateDirTTL("/non-existent-key", 1)
-				Expect(err).To(Equal(ErrorKeyNotFound))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorKeyNotFound))
+				} else {
+					Fail("expected error to be of type ErrorKeyNotFound")
+				}
 			})
 		})
 
@@ -1282,7 +1432,11 @@ var _ = Describe("ETCD Store Adapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = adapter.UpdateDirTTL("/menu/breakfast", 1)
-				Expect(err).To(Equal(ErrorNodeIsNotDirectory))
+				if cErr, ok := err.(Error); ok {
+					Expect(cErr.Type()).To(Equal(ErrorNodeIsDirectory))
+				} else {
+					Fail("expected error to be of type ErrorNodeIsDirectory")
+				}
 			})
 		})
 	})

--- a/fakestoreadapter/fakestoreadapter_test.go
+++ b/fakestoreadapter/fakestoreadapter_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Fakestoreadapter", func() {
 		Context("when creating an existing key", func() {
 			It("should error", func() {
 				err := adapter.Create(firstCourseDinnerNode)
-				Expect(err).To(Equal(storeadapter.ErrorKeyExists))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyExists))
 			})
 		})
 
@@ -129,7 +129,7 @@ var _ = Describe("Fakestoreadapter", func() {
 					Value: []byte("oops"),
 				}
 				err := adapter.SetMulti([]storeadapter.StoreNode{badMenu})
-				Expect(err).To(Equal(storeadapter.ErrorNodeIsDirectory))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorNodeIsDirectory))
 
 				value, err := adapter.Get("/menu/breakfast")
 				Expect(err).NotTo(HaveOccurred())
@@ -144,7 +144,7 @@ var _ = Describe("Fakestoreadapter", func() {
 					Value: []byte("oops"),
 				}
 				err := adapter.SetMulti([]storeadapter.StoreNode{badBreakfast})
-				Expect(err).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
 
 				value, err := adapter.Get("/menu/breakfast")
 				Expect(err).NotTo(HaveOccurred())
@@ -197,7 +197,7 @@ var _ = Describe("Fakestoreadapter", func() {
 		Context("when the key is missing", func() {
 			It("should return the key not found error", func() {
 				value, err := adapter.Get("/not/a/key")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 				Expect(value).To(BeZero())
 			})
 		})
@@ -205,7 +205,7 @@ var _ = Describe("Fakestoreadapter", func() {
 		Context("when the key is a directory", func() {
 			It("should return the key not found error", func() {
 				value, err := adapter.Get("/menu")
-				Expect(err).To(Equal(storeadapter.ErrorNodeIsDirectory))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorNodeIsDirectory))
 				Expect(value).To(BeZero())
 			})
 		})
@@ -282,7 +282,7 @@ var _ = Describe("Fakestoreadapter", func() {
 		Context("when listing a nonexistent key", func() {
 			It("should return the key not found error", func() {
 				value, err := adapter.ListRecursively("/not-a-key")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 				Expect(value).To(BeZero())
 			})
 		})
@@ -290,7 +290,7 @@ var _ = Describe("Fakestoreadapter", func() {
 		Context("when listing an entry", func() {
 			It("should return the key is not a directory error", func() {
 				value, err := adapter.ListRecursively("/menu/breakfast")
-				Expect(err).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
 				Expect(value).To(BeZero())
 			})
 		})
@@ -299,7 +299,7 @@ var _ = Describe("Fakestoreadapter", func() {
 			It("should return the injected error", func() {
 				adapter.ListErrInjector = NewFakeStoreAdapterErrorInjector("menu", errors.New("injected list error"))
 				value, err := adapter.ListRecursively("/menu")
-				Expect(err).To(Equal(errors.New("injected list error")))
+				Expect(err.(storeadapter.Error).Error()).To(Equal("injected list error"))
 				Expect(value).To(BeZero())
 			})
 		})
@@ -312,17 +312,17 @@ var _ = Describe("Fakestoreadapter", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = adapter.Get("/menu/breakfast")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 
 				_, err = adapter.Get("/menu/lunch")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 		})
 
 		Context("when the key is missing", func() {
 			It("should return the key not found error", func() {
 				err := adapter.Delete("/not/a/key")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 		})
 
@@ -333,7 +333,7 @@ var _ = Describe("Fakestoreadapter", func() {
 
 				_, err = adapter.Get("/menu")
 				_, err = adapter.Get("/menu")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 
 			It("should send a delete event", func() {
@@ -351,7 +351,7 @@ var _ = Describe("Fakestoreadapter", func() {
 				adapter.Delete("/menu")
 
 				_, err := adapter.Get("/menu/breakfast")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 
 				// /menu, /menu/breakfast, /menu/lunch, /menu/dinner, /menu/dinner/first, /menu/dinner/second
 				for i := 0; i < 6; i++ {
@@ -403,7 +403,7 @@ var _ = Describe("Fakestoreadapter", func() {
 			It("returns a KeyNotFound error", func() {
 
 				err := adapter.CompareAndDelete(nodeFoo)
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 		})
 
@@ -414,7 +414,7 @@ var _ = Describe("Fakestoreadapter", func() {
 
 			It("does NOT delete the existing node and returns a KeyComparisonFailed error", func() {
 				err := adapter.CompareAndDelete(nodeBar)
-				Expect(err).To(Equal(storeadapter.ErrorKeyComparisonFailed))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyComparisonFailed))
 				node, _ := adapter.Get("/foo")
 				Expect(node).To(Equal(nodeFoo))
 			})
@@ -429,7 +429,7 @@ var _ = Describe("Fakestoreadapter", func() {
 				err := adapter.CompareAndDelete(nodeFoo)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = adapter.Get("/foo")
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 		})
 	})
@@ -437,7 +437,7 @@ var _ = Describe("Fakestoreadapter", func() {
 	Describe("Updating Dir TTL", func() {
 		It("should return a NotADirectory error if the key is not a directory", func() {
 			err := adapter.UpdateDirTTL("/menu/breakfast", 1)
-			Expect(err).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
+			Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorNodeIsNotDirectory))
 		})
 
 		It("should not return an error if the directory exists", func() {
@@ -447,9 +447,18 @@ var _ = Describe("Fakestoreadapter", func() {
 
 		It("should delete the key after the timeout", func() {
 			adapter.UpdateDirTTL("/menu", 1)
-			getErr := func() error { _, err := adapter.ListRecursively("/menu"); return err }
+			getErr := func() error {
+				_, err := adapter.ListRecursively("/menu")
+				return err
+			}
 			Consistently(getErr, 0.9).Should(Succeed())
-			Eventually(getErr, 0.2).Should(Equal(storeadapter.ErrorKeyNotFound))
+			Eventually(func() int {
+				e := getErr()
+				if e != nil {
+					return e.(storeadapter.Error).Type()
+				}
+				return -1
+			}, 0.2).Should(Equal(storeadapter.ErrorKeyNotFound))
 		})
 	})
 
@@ -462,7 +471,7 @@ var _ = Describe("Fakestoreadapter", func() {
 				}
 
 				err := adapter.CompareAndSwap(node, node)
-				Expect(err).To(Equal(storeadapter.ErrorKeyNotFound))
+				Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyNotFound))
 			})
 		})
 
@@ -491,7 +500,7 @@ var _ = Describe("Fakestoreadapter", func() {
 			Context("and the Value of oldNode is different", func() {
 				It("returns a KeyComparisonFailed error", func() {
 					err := adapter.CompareAndSwap(nodeBar, nodeBar)
-					Expect(err).To(Equal(storeadapter.ErrorKeyComparisonFailed))
+					Expect(err.(storeadapter.Error).Type()).To(Equal(storeadapter.ErrorKeyComparisonFailed))
 				})
 
 				It("does not update the existing node", func() {

--- a/retryable.go
+++ b/retryable.go
@@ -116,7 +116,7 @@ func (adapter *retryable) retry(action func() error) error {
 	var failedAttempts uint
 	for {
 		err = action()
-		if err != ErrorTimeout {
+		if cErr, ok := err.(Error); ok && cErr.Type() != ErrorTimeout {
 			break
 		}
 

--- a/retryable_test.go
+++ b/retryable_test.go
@@ -37,7 +37,8 @@ var _ = Describe("Retryable", func() {
 
 		Context("when the store adapter returns a timeout error", func() {
 			BeforeEach(func() {
-				resultIn(ErrorTimeout)
+				errorTimeout := NewError(errors.New("timeout"), ErrorTimeout)
+				resultIn(errorTimeout)
 			})
 
 			Context("as long as the backoff policy returns true", func() {
@@ -71,7 +72,11 @@ var _ = Describe("Retryable", func() {
 					Expect(retryPolicy.DelayForArgsForCall(2)).To(Equal(uint(3)))
 					Expect(sleeper.SleepArgsForCall(2)).To(Equal(1000 * time.Second))
 
-					Expect(errResult).To(Equal(ErrorTimeout))
+					if cErr, ok := errResult.(Error); ok {
+						Expect(cErr.Type()).To(Equal(ErrorTimeout))
+					} else {
+						Fail("expected the error to be a storeadapter.Error")
+					}
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: Dan Lavine dlavine@us.ibm.com

Right now the convertErrors() method in etcdstoreadapter masks errors - for example, a failure to connect shows up as ErrorTimeout, which is not strictly accurate in terms of diagnosing underlying failures.

Our change does have the result that users can no longer do simple equivalence checks to determine if an error has a specific type, however, but we don't see any way around that if we still want to pass the underlying errors through while still preserving the existing storeadapter-specific error text.
